### PR TITLE
feat: add video on the home page

### DIFF
--- a/coffee-house/index.html
+++ b/coffee-house/index.html
@@ -73,6 +73,9 @@
       <main class="main">
         <section class="main__enjoy-section">
           <div class="enjoy-section__container">
+            <div class="enjoy-section__video">
+              <video src="./assets/video/video (2160p).mp4" autoplay="true" loop="true" muted="true"></video>
+            </div>
             <div class="enjoy-section__content">
               <h1 class="enjoy-section__title">
                 <i class="_italic">Enjoy</i> premium coffee at our charming cafe
@@ -120,11 +123,11 @@
                 </div>
                 <div class="slider__dashes">
                   <progress class="dash__progress" max="100" min="0" value="0"></progress>
-                  <progress class="dash__progress"  max="100" min="0" value="0"></progress>
-                  <progress class="dash__progress"  max="100" min="0" value="0"></progress>
+                  <progress class="dash__progress" max="100" min="0" value="0"></progress>
+                  <progress class="dash__progress" max="100" min="0" value="0"></progress>
                 </div>
               </div>
-              <div class="slider__button-right-container"> 
+              <div class="slider__button-right-container">
                 <button class="button-right slider-button next-slide">
                   <svg class="arrow" width="24" height="24" viewBox="0 0 24 24" fill="none"
                     xmlns="http://www.w3.org/2000/svg">
@@ -133,7 +136,8 @@
                         stroke-linecap="round" stroke-linejoin="round" />
                     </g>
                   </svg>
-                </button></div>
+                </button>
+              </div>
             </div>
           </div>
         </section>

--- a/coffee-house/menuPage.html
+++ b/coffee-house/menuPage.html
@@ -76,7 +76,7 @@
               Behind each of our cups hides an <i class="_italic">amazing surprise</i>
             </p>
             <div class="amazing-section__buttons-container">
-              <div class="amazing-section__button _coffee-btn">
+              <div class="amazing-section__button _coffee-btn active-menu-button">
                 <div class="amazing-section__button-icon-container">
                   <img src="./assets/menu/coffe-cup.svg" alt="coffee cup icon">
                 </div>

--- a/coffee-house/style.css
+++ b/coffee-house/style.css
@@ -291,11 +291,7 @@ progress::-moz-progress-bar {
 /*----------------------------ENJOY---------------------------------*/
 
 .main__enjoy-section {
-    background-image: url('./assets/img-hero.png');
-    background-position: center;
-    background-size: cover;
     position: relative;
-    border-radius: 40px;
     width: 100%;
     margin-bottom: 6.25em;
 }
@@ -304,6 +300,22 @@ progress::-moz-progress-bar {
     position: relative;
     z-index: 1;
     padding: 6.25em;
+}
+
+.enjoy-section__video {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    z-index: -3;
+}
+
+.enjoy-section__video video {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 40px;
 }
 
 .enjoy-section__content {


### PR DESCRIPTION
16.02.2024
- In the Enjoy block of the home page, a video is played in the background instead of an image, without sound and control elements, and without the ability to interact with it
- After the video is finished, it automatically starts over